### PR TITLE
feat: bump podman 4.7.0, update dep and go version

### DIFF
--- a/Dockerfile-remote
+++ b/Dockerfile-remote
@@ -1,5 +1,5 @@
 # podman build base
-FROM golang:1.18-alpine3.17 AS podmanbuildbase
+FROM golang:1.19-alpine3.18 AS podmanbuildbase
 RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 	btrfs-progs btrfs-progs-dev libassuan-dev lvm2-dev device-mapper \
 	glib-static libc-dev gpgme-dev protobuf-dev protobuf-c-dev \
@@ -9,8 +9,8 @@ RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 # podman remote
 FROM podmanbuildbase AS podman-remote
 RUN apk add --update --no-cache curl
-ARG PODMAN_VERSION=v4.6.2
-RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch ${PODMAN_VERSION} https://github.com/containers/podman src/github.com/containers/podman
+ARG PODMAN_VERSION=v4.7.0
+RUN git clone -c advice.detachedHead=false --depth=1 --branch=${PODMAN_VERSION} https://github.com/containers/podman src/github.com/containers/podman
 WORKDIR $GOPATH/src/github.com/containers/podman
 RUN make install.tools
 RUN set -eux; \


### PR DESCRIPTION
dependency updates:
* podman 4.7.0
* catatonit 0.2.0
* crun 1.9.2

Using Go 1.19 on alpine:3.18 to build the binaries.