### PR TITLE
update versions, podman 4.7.2, runc 1.1.10, libfuse 3.16.2, crun 1.11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache gnupg
 
 # runc
 FROM golang:1.19-alpine3.18 AS runc
-ARG RUNC_VERSION=v1.1.9
+ARG RUNC_VERSION=v1.1.10
 # Download runc binary release since static build doesn't work with musl libc anymore since 1.1.8, see https://github.com/opencontainers/runc/issues/3950
 RUN set -eux; \
 	ARCH="`uname -m | sed 's!x86_64!amd64!; s!aarch64!arm64!'`"; \
@@ -27,7 +27,7 @@ RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 # podman (without systemd support)
 FROM podmanbuildbase AS podman
 RUN apk add --update --no-cache tzdata curl
-ARG PODMAN_VERSION=v4.7.1
+ARG PODMAN_VERSION=v4.7.2
 ARG PODMAN_BUILDTAGS='seccomp selinux apparmor exclude_graphdriver_devicemapper containers_image_openpgp'
 ARG PODMAN_CGO=1
 RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch ${PODMAN_VERSION} https://github.com/containers/podman src/github.com/containers/podman
@@ -96,7 +96,7 @@ RUN set -ex; \
 # fuse-overlayfs (derived from https://github.com/containers/fuse-overlayfs/blob/master/Dockerfile.static)
 FROM podmanbuildbase AS fuse-overlayfs
 RUN apk add --update --no-cache autoconf automake meson ninja clang g++ eudev-dev fuse3-dev
-ARG LIBFUSE_VERSION=fuse-3.16.1
+ARG LIBFUSE_VERSION=fuse-3.16.2
 RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch=$LIBFUSE_VERSION https://github.com/libfuse/libfuse /libfuse
 WORKDIR /libfuse
 RUN set -ex; \
@@ -166,7 +166,7 @@ COPY --from=runc   /usr/local/bin/runc   /usr/local/bin/runc
 # Download crun
 # (switched keyserver from sks to ubuntu since sks is offline now and gpg refuses to import keys from keys.openpgp.org because it does not provide a user ID with the key.)
 FROM gpg AS crun
-ARG CRUN_VERSION=1.9.2
+ARG CRUN_VERSION=1.11.2
 RUN set -ex; \
 	wget -O /usr/local/bin/crun https://github.com/containers/crun/releases/download/$CRUN_VERSION/crun-${CRUN_VERSION}-linux-amd64-disable-systemd; \
 	wget -O /tmp/crun.asc https://github.com/containers/crun/releases/download/$CRUN_VERSION/crun-${CRUN_VERSION}-linux-amd64-disable-systemd.asc; \

--- a/Dockerfile-remote
+++ b/Dockerfile-remote
@@ -9,7 +9,7 @@ RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 # podman remote
 FROM podmanbuildbase AS podman-remote
 RUN apk add --update --no-cache curl
-ARG PODMAN_VERSION=v4.7.1
+ARG PODMAN_VERSION=v4.7.2
 RUN git clone -c advice.detachedHead=false --depth=1 --branch=${PODMAN_VERSION} https://github.com/containers/podman src/github.com/containers/podman
 WORKDIR $GOPATH/src/github.com/containers/podman
 RUN make install.tools


### PR DESCRIPTION
version checks after building the updated images..

```
$ podman run --rm -it podman /bin/sh
/ # podman --version
podman version 4.7.2
/ # runc --version
runc version 1.1.10
commit: v1.1.10-0-g18a0cb0f
spec: 1.0.2-dev
go: go1.20.10
libseccomp: 2.5.4
/ # fuse-overlayfs --version
unknown argument ignored: lazytime
fuse-overlayfs: version 1.13-dev
FUSE library version 3.16.2
using FUSE kernel interface version 7.38
fusermount3 version: 3.16.2
```

... and crun version check from the minimal image..

```
$ podman run --rm -it podman-minimal /bin/sh
/ # crun --version
crun version 1.11.2
commit: ab0edeef1c331840b025e8f1d38090cfb8a0509d
rundir: /run/crun
spec: 1.0.0
+SELINUX +APPARMOR +CAP +SECCOMP +EBPF +CRIU +YAJL
```
