### PR TITLE
Update to podman 5, including netavark and pasta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,29 @@ RUN set -ex; \
 	done
 
 
+# slirp4netns
+FROM podmanbuildbase AS slirp4netns
+WORKDIR /
+RUN apk add --update --no-cache autoconf automake meson ninja linux-headers libcap-static libcap-dev clang llvm
+# Build libslirp
+ARG LIBSLIRP_VERSION=v4.7.0
+RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch=${LIBSLIRP_VERSION} https://gitlab.freedesktop.org/slirp/libslirp.git
+WORKDIR /libslirp
+RUN set -ex; \
+	rm -rf /usr/lib/libglib-2.0.so /usr/lib/libintl.so; \
+	ln -s /usr/bin/clang /go/bin/clang; \
+	LDFLAGS="-s -w -static" meson --prefix /usr -D default_library=static build; \
+	ninja -C build install
+# Build slirp4netns
+WORKDIR /
+ARG SLIRP4NETNS_VERSION=v1.2.3
+RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch $SLIRP4NETNS_VERSION https://github.com/rootless-containers/slirp4netns.git
+WORKDIR /slirp4netns
+RUN set -ex; \
+	./autogen.sh; \
+	LDFLAGS=-static ./configure --prefix=/usr; \
+	make
+
 # netavark
 FROM podmanbuildbase AS netavark
 WORKDIR /
@@ -182,6 +205,7 @@ COPY conf/crun-containers.conf /etc/containers/containers.conf
 # Build podman image with rootless binaries and CNI plugins
 FROM rootlesspodmanrunc AS podmanall
 RUN apk add --no-cache iptables ip6tables
+COPY --from=slirp4netns /slirp4netns/slirp4netns /usr/local/bin/slirp4netns
 COPY --from=passt /passt/pasta /usr/local/bin/pasta
 COPY --from=netavark /netavark/bin/netavark /usr/local/lib/podman/netavark
 COPY --from=cniplugins /usr/local/lib/cni /usr/local/lib/cni

--- a/Dockerfile-remote
+++ b/Dockerfile-remote
@@ -9,7 +9,7 @@ RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 # podman remote
 FROM podmanbuildbase AS podman-remote
 RUN apk add --update --no-cache curl
-ARG PODMAN_VERSION=v4.9.4
+ARG PODMAN_VERSION=v5.0.0
 RUN git clone -c advice.detachedHead=false --depth=1 --branch=${PODMAN_VERSION} https://github.com/containers/podman src/github.com/containers/podman
 WORKDIR $GOPATH/src/github.com/containers/podman
 RUN set -eux; \

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,7 @@ tar: .podman-from-container
 	cp -r conf/containers $(ASSET_DIR)/etc/containers
 	cp -r conf/cni $(ASSET_DIR)/etc/cni
 	cp README.md $(ASSET_DIR)/
-	cp -r $(IMAGE_ROOTFS)/usr/local/lib $(ASSET_DIR)/usr/local/lib
-	cp -r $(IMAGE_ROOTFS)/usr/local/bin $(ASSET_DIR)/usr/local/bin
+	$(DOCKER) run --rm $(PODMAN_IMAGE) tar c /usr/local/{bin,lib} | tar -xC $(ASSET_DIR)
 
 signed-tar: tar .gpg
 	@echo Running gpg signing container with GPG_SIGN_KEY and GPG_SIGN_KEY_PASSPHRASE


### PR DESCRIPTION
- Remove slirp4netns, and replace with pasta
- Build and install netavark
- Upgrade to podman 5.0.0