### PR TITLE
Upgrade v5.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
       with:
         platforms: all
 
+    - name: Print environment
+      run: |
+        uname -a
+        docker --version
+
     - name: Build & test
       run: make images test
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,6 +20,11 @@ jobs:
       with:
         platforms: all
 
+    - name: Print environment
+      run: |
+        uname -a
+        docker --version
+
     - name: Build & test linux/amd64 image
       run: make images test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 # podman (without systemd support)
 FROM podmanbuildbase AS podman
 RUN apk add --update --no-cache tzdata curl
-ARG PODMAN_VERSION=v4.9.5
+ARG PODMAN_VERSION=v5.0.0
 ARG PODMAN_BUILDTAGS='seccomp selinux apparmor exclude_graphdriver_devicemapper containers_image_openpgp'
 ARG PODMAN_CGO=1
 RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch ${PODMAN_VERSION} https://github.com/containers/podman src/github.com/containers/podman
@@ -91,6 +91,27 @@ RUN set -ex; \
 	./autogen.sh; \
 	LDFLAGS=-static ./configure --prefix=/usr; \
 	make
+
+# netavark
+FROM podmanbuildbase AS netavark
+WORKDIR /
+RUN apk add --update --no-cache cargo
+# Build passt
+ARG NETAVARK_VERSION=v1.10.3
+RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch=${NETAVARK_VERSION} https://github.com/containers/netavark
+WORKDIR /netavark
+RUN LDFLAGS=-static make
+
+
+# passt
+FROM podmanbuildbase AS passt
+WORKDIR /
+RUN apk add --update --no-cache autoconf automake meson ninja linux-headers libcap-static libcap-dev clang llvm coreutils
+# Build passt
+ARG PASST_VERSION=2024_04_05.954589b
+RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch=${PASST_VERSION} git://passt.top/passt
+WORKDIR /passt
+RUN make static
 
 
 # fuse-overlayfs (derived from https://github.com/containers/fuse-overlayfs/blob/master/Dockerfile.static)
@@ -185,6 +206,8 @@ COPY conf/crun-containers.conf /etc/containers/containers.conf
 FROM rootlesspodmanrunc AS podmanall
 RUN apk add --no-cache iptables ip6tables
 COPY --from=slirp4netns /slirp4netns/slirp4netns /usr/local/bin/slirp4netns
+COPY --from=passt /passt/pasta /usr/local/bin/pasta
+COPY --from=netavark /netavark/bin/netavark /usr/local/lib/podman/netavark
 COPY --from=cniplugins /usr/local/lib/cni /usr/local/lib/cni
 COPY --from=catatonit /catatonit/catatonit /usr/local/lib/podman/catatonit
 COPY conf/cni /etc/cni

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Download gpg
-FROM alpine:3.18 AS gpg
+FROM alpine:3.19 AS gpg
 RUN apk add --no-cache gnupg
 
 
 # runc
-FROM golang:1.20-alpine3.18 AS runc
+FROM golang:1.22-alpine3.19 AS runc
 ARG RUNC_VERSION=v1.1.12
 # Download runc binary release since static build doesn't work with musl libc anymore since 1.1.8, see https://github.com/opencontainers/runc/issues/3950
 RUN set -eux; \
@@ -16,7 +16,7 @@ RUN set -eux; \
 
 
 # podman build base
-FROM golang:1.20-alpine3.18 AS podmanbuildbase
+FROM golang:1.22-alpine3.19 AS podmanbuildbase
 RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 	btrfs-progs btrfs-progs-dev libassuan-dev lvm2-dev device-mapper \
 	glib-static libc-dev gpgme-dev protobuf-dev protobuf-c-dev \
@@ -27,7 +27,7 @@ RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 # podman (without systemd support)
 FROM podmanbuildbase AS podman
 RUN apk add --update --no-cache tzdata curl
-ARG PODMAN_VERSION=v5.0.0
+ARG PODMAN_VERSION=v5.1.1
 ARG PODMAN_BUILDTAGS='seccomp selinux apparmor exclude_graphdriver_devicemapper containers_image_openpgp'
 ARG PODMAN_CGO=1
 RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch ${PODMAN_VERSION} https://github.com/containers/podman src/github.com/containers/podman
@@ -47,7 +47,7 @@ RUN set -ex; \
 
 # conmon (without systemd support)
 FROM podmanbuildbase AS conmon
-ARG CONMON_VERSION=v2.1.10
+ARG CONMON_VERSION=v2.1.11
 RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch ${CONMON_VERSION} https://github.com/containers/conmon.git /conmon
 WORKDIR /conmon
 RUN set -ex; \
@@ -55,63 +55,42 @@ RUN set -ex; \
 	bin/conmon --help >/dev/null
 
 
-# CNI plugins
-FROM podmanbuildbase AS cniplugins
-ARG CNI_PLUGIN_VERSION=v1.4.1
-ARG CNI_PLUGINS="ipam/host-local main/loopback main/bridge meta/portmap meta/tuning meta/firewall"
-RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch=${CNI_PLUGIN_VERSION} https://github.com/containernetworking/plugins /go/src/github.com/containernetworking/plugins
-WORKDIR /go/src/github.com/containernetworking/plugins
-RUN set -ex; \
-	for PLUGINDIR in $CNI_PLUGINS; do \
-		PLUGINBIN=/usr/local/lib/cni/$(basename $PLUGINDIR); \
-		CGO_ENABLED=0 go build -o $PLUGINBIN -ldflags "-s -w -extldflags '-static'" ./plugins/$PLUGINDIR; \
-		! ldd $PLUGINBIN; \
-	done
+FROM rust:1.78-alpine3.19 AS rustbase
+RUN apk add --update --no-cache git make musl-dev
 
-
-# slirp4netns
-FROM podmanbuildbase AS slirp4netns
-WORKDIR /
-RUN apk add --update --no-cache autoconf automake meson ninja linux-headers libcap-static libcap-dev clang llvm
-# Build libslirp
-ARG LIBSLIRP_VERSION=v4.7.0
-RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch=${LIBSLIRP_VERSION} https://gitlab.freedesktop.org/slirp/libslirp.git
-WORKDIR /libslirp
-RUN set -ex; \
-	rm -rf /usr/lib/libglib-2.0.so /usr/lib/libintl.so; \
-	ln -s /usr/bin/clang /go/bin/clang; \
-	LDFLAGS="-s -w -static" meson --prefix /usr -D default_library=static build; \
-	ninja -C build install
-# Build slirp4netns
-WORKDIR /
-ARG SLIRP4NETNS_VERSION=v1.2.3
-RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch $SLIRP4NETNS_VERSION https://github.com/rootless-containers/slirp4netns.git
-WORKDIR /slirp4netns
-RUN set -ex; \
-	./autogen.sh; \
-	LDFLAGS=-static ./configure --prefix=/usr; \
-	make
 
 # netavark
-FROM podmanbuildbase AS netavark
-WORKDIR /
-RUN apk add --update --no-cache cargo
-# Build passt
+FROM rustbase AS netavark
+RUN apk add --update --no-cache protoc
 ARG NETAVARK_VERSION=v1.10.3
-RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch=${NETAVARK_VERSION} https://github.com/containers/netavark
+RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch=$NETAVARK_VERSION https://github.com/containers/netavark
 WORKDIR /netavark
-RUN LDFLAGS=-static make
+ENV RUSTFLAGS='-C link-arg=-s'
+RUN cargo build --release
+
+
+# aardvark-dns
+FROM rustbase AS aardvark-dns
+ARG AARDVARKDNS_VERSION=v1.10.0
+RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch=$AARDVARKDNS_VERSION https://github.com/containers/aardvark-dns
+WORKDIR /aardvark-dns
+ENV RUSTFLAGS='-C link-arg=-s'
+RUN cargo build --release
 
 
 # passt
 FROM podmanbuildbase AS passt
 WORKDIR /
 RUN apk add --update --no-cache autoconf automake meson ninja linux-headers libcap-static libcap-dev clang llvm coreutils
-# Build passt
-ARG PASST_VERSION=2024_04_05.954589b
-RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch=${PASST_VERSION} git://passt.top/passt
+ARG PASST_VERSION=2024_05_23.765eb0b
+RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch=$PASST_VERSION git://passt.top/passt
 WORKDIR /passt
-RUN make static
+RUN set -ex; \
+	make static; \
+	mkdir bin; \
+	cp pasta bin/; \
+	[ ! -f pasta.avx2 ] || cp pasta.avx2 bin/; \
+	! ldd /passt/bin/pasta
 
 
 # fuse-overlayfs (derived from https://github.com/containers/fuse-overlayfs/blob/master/Dockerfile.static)
@@ -129,7 +108,7 @@ RUN set -ex; \
 	ninja install; \
 	fusermount3 -V
 ARG FUSEOVERLAYFS_VERSION=v1.13
-RUN git clone -c advice.detachedHead=false --depth=1 --branch=$FUSEOVERLAYFS_VERSION https://github.com/containers/fuse-overlayfs /fuse-overlayfs
+RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch=$FUSEOVERLAYFS_VERSION https://github.com/containers/fuse-overlayfs /fuse-overlayfs
 WORKDIR /fuse-overlayfs
 RUN set -ex; \
 	sh autogen.sh; \
@@ -143,7 +122,7 @@ RUN set -ex; \
 FROM podmanbuildbase AS catatonit
 RUN apk add --update --no-cache autoconf automake libtool
 ARG CATATONIT_VERSION=v0.2.0
-RUN git clone --branch=$CATATONIT_VERSION https://github.com/openSUSE/catatonit.git /catatonit
+RUN git clone -c 'advice.detachedHead=false' --branch=$CATATONIT_VERSION https://github.com/openSUSE/catatonit.git /catatonit
 WORKDIR /catatonit
 RUN set -ex; \
 	./autogen.sh; \
@@ -152,13 +131,29 @@ RUN set -ex; \
 	./catatonit --version
 
 
+# Download crun
+# (switched keyserver from sks to ubuntu since sks is offline now and gpg refuses to import keys from keys.openpgp.org because it does not provide a user ID with the key.)
+FROM gpg AS crun
+ARG CRUN_VERSION=1.15
+RUN set -ex; \
+	ARCH="`uname -m | sed 's!x86_64!amd64!; s!aarch64!arm64!'`"; \
+	wget -O /usr/local/bin/crun https://github.com/containers/crun/releases/download/$CRUN_VERSION/crun-${CRUN_VERSION}-linux-${ARCH}-disable-systemd; \
+	wget -O /tmp/crun.asc https://github.com/containers/crun/releases/download/$CRUN_VERSION/crun-${CRUN_VERSION}-linux-${ARCH}-disable-systemd.asc; \
+	gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 027F3BD58594CA181BB5EC50E4730F97F60286ED; \
+	gpg --batch --verify /tmp/crun.asc /usr/local/bin/crun; \
+	chmod +x /usr/local/bin/crun; \
+	! ldd /usr/local/bin/crun
+
+
 # Build podman base image
-FROM alpine:3.18 AS podmanbase
+FROM alpine:3.19 AS podmanbase
 LABEL maintainer="Max Goltzsche <max.goltzsche@gmail.com>"
 RUN apk add --no-cache tzdata ca-certificates
 COPY --from=conmon /conmon/bin/conmon /usr/local/lib/podman/conmon
 COPY --from=podman /usr/local/lib/podman/rootlessport /usr/local/lib/podman/rootlessport
 COPY --from=podman /usr/local/bin/podman /usr/local/bin/podman
+COPY --from=passt /passt/bin/ /usr/local/bin/
+COPY --from=netavark /netavark/target/release/netavark /usr/local/lib/podman/netavark
 COPY conf/containers /etc/containers
 RUN set -ex; \
 	adduser -D podman -h /podman -u 1000; \
@@ -179,35 +174,15 @@ ENV BUILDAH_ISOLATION=chroot container=oci
 RUN apk add --no-cache shadow-uidmap
 COPY --from=fuse-overlayfs /usr/bin/fuse-overlayfs /usr/local/bin/fuse-overlayfs
 COPY --from=fuse-overlayfs /usr/bin/fusermount3 /usr/local/bin/fusermount3
-
-# Build rootless podman base image with runc
-FROM rootlesspodmanbase AS rootlesspodmanrunc
-COPY --from=runc   /usr/local/bin/runc   /usr/local/bin/runc
-
-# Download crun
-# (switched keyserver from sks to ubuntu since sks is offline now and gpg refuses to import keys from keys.openpgp.org because it does not provide a user ID with the key.)
-FROM gpg AS crun
-ARG CRUN_VERSION=1.14.4
-RUN set -ex; \
-	ARCH="`uname -m | sed 's!x86_64!amd64!; s!aarch64!arm64!'`"; \
-	wget -O /usr/local/bin/crun https://github.com/containers/crun/releases/download/$CRUN_VERSION/crun-${CRUN_VERSION}-linux-${ARCH}-disable-systemd; \
-	wget -O /tmp/crun.asc https://github.com/containers/crun/releases/download/$CRUN_VERSION/crun-${CRUN_VERSION}-linux-${ARCH}-disable-systemd.asc; \
-	gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 027F3BD58594CA181BB5EC50E4730F97F60286ED; \
-	gpg --batch --verify /tmp/crun.asc /usr/local/bin/crun; \
-	chmod +x /usr/local/bin/crun; \
-	! ldd /usr/local/bin/crun
+COPY --from=crun /usr/local/bin/crun /usr/local/bin/crun
 
 # Build minimal rootless podman
 FROM rootlesspodmanbase AS rootlesspodmanminimal
-COPY --from=crun /usr/local/bin/crun /usr/local/bin/crun
 COPY conf/crun-containers.conf /etc/containers/containers.conf
 
-# Build podman image with rootless binaries and CNI plugins
-FROM rootlesspodmanrunc AS podmanall
+# Build podman image with all binaries
+FROM rootlesspodmanbase AS podmanall
 RUN apk add --no-cache iptables ip6tables
-COPY --from=slirp4netns /slirp4netns/slirp4netns /usr/local/bin/slirp4netns
-COPY --from=passt /passt/pasta /usr/local/bin/pasta
-COPY --from=netavark /netavark/bin/netavark /usr/local/lib/podman/netavark
-COPY --from=cniplugins /usr/local/lib/cni /usr/local/lib/cni
 COPY --from=catatonit /catatonit/catatonit /usr/local/lib/podman/catatonit
-COPY conf/cni /etc/cni
+COPY --from=runc   /usr/local/bin/runc   /usr/local/bin/runc
+COPY --from=aardvark-dns /aardvark-dns/target/release/aardvark-dns /usr/local/lib/podman/aardvark-dns

--- a/Dockerfile-remote
+++ b/Dockerfile-remote
@@ -1,5 +1,5 @@
 # podman build base
-FROM golang:1.20-alpine3.18 AS podmanbuildbase
+FROM golang:1.22-alpine3.19 AS podmanbuildbase
 RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 	btrfs-progs btrfs-progs-dev libassuan-dev lvm2-dev device-mapper \
 	glib-static libc-dev gpgme-dev protobuf-dev protobuf-c-dev \
@@ -9,7 +9,7 @@ RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 # podman remote
 FROM podmanbuildbase AS podman-remote
 RUN apk add --update --no-cache curl
-ARG PODMAN_VERSION=v5.0.0
+ARG PODMAN_VERSION=v5.1.1
 RUN git clone -c advice.detachedHead=false --depth=1 --branch=${PODMAN_VERSION} https://github.com/containers/podman src/github.com/containers/podman
 WORKDIR $GOPATH/src/github.com/containers/podman
 RUN set -eux; \
@@ -20,6 +20,6 @@ RUN set -eux; \
 	podman --help >/dev/null; \
 	[ "$(ldd /usr/local/bin/podman-remote | wc -l)" -eq 0 ] || (ldd /usr/local/bin/podman-remote; false)
 
-FROM alpine:3.18
+FROM alpine:3.19
 COPY --from=podman-remote /usr/local/bin /usr/local/bin
 RUN adduser -D podman-remote -h /podman -u 1000

--- a/Dockerfile-remote
+++ b/Dockerfile-remote
@@ -9,7 +9,7 @@ RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 # podman remote
 FROM podmanbuildbase AS podman-remote
 RUN apk add --update --no-cache curl
-ARG PODMAN_VERSION=v4.9.5
+ARG PODMAN_VERSION=v5.0.0
 RUN git clone -c advice.detachedHead=false --depth=1 --branch=${PODMAN_VERSION} https://github.com/containers/podman src/github.com/containers/podman
 WORKDIR $GOPATH/src/github.com/containers/podman
 RUN set -eux; \

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,7 @@ tar: .podman-from-container
 	cp -r conf/containers $(ASSET_DIR)/etc/containers
 	cp -r conf/cni $(ASSET_DIR)/etc/cni
 	cp README.md $(ASSET_DIR)/
-	cp -r $(IMAGE_ROOTFS)/usr/local/lib $(ASSET_DIR)/usr/local/lib
-	cp -r $(IMAGE_ROOTFS)/usr/local/bin $(ASSET_DIR)/usr/local/bin
+	$(DOCKER) run --rm $(PODMAN_IMAGE) tar c /usr/local/{bin,lib} | tar -xC $(ASSET_DIR)
 
 signed-tar: tar .gpg
 	@echo Running gpg signing container with GPG_SIGN_KEY and GPG_SIGN_KEY_PASSPHRASE

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GPG_IMAGE = gpg-signer
 
 BUILD_DIR = ./build
 
-BATS_VERSION = v1.8.2
+BATS_VERSION = v1.11.0
 BATS_DIR := $(BUILD_DIR)/bats-$(BATS_VERSION)
 BATS = $(BATS_DIR)/bin/bats
 BATS_TEST ?= test
@@ -102,7 +102,6 @@ tar: .podman-from-container
 	rm -rf $(ASSET_DIR)
 	mkdir -p $(ASSET_DIR)/etc $(ASSET_DIR)/usr/local
 	cp -r conf/containers $(ASSET_DIR)/etc/containers
-	cp -r conf/cni $(ASSET_DIR)/etc/cni
 	cp README.md $(ASSET_DIR)/
 	$(DOCKER) run --rm $(PODMAN_IMAGE) tar c /usr/local/{bin,lib} | tar -xC $(ASSET_DIR)
 
@@ -145,7 +144,7 @@ run:
 		$(PODMAN_IMAGE) /bin/sh
 
 clean:
-	$(DOCKER) run --rm -v "`pwd`:/work" alpine:3.18 rm -rf /work/build
+	$(DOCKER) run --rm -v "`pwd`:/work" alpine:3.19 rm -rf /work/build
 
 run-server: podman-ssh
 	# TODO: make sshd log to stdout (while still ensuring that we know when it is available)

--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 
 This project provides alpine-based podman container images and statically linked (rootless) podman binaries for linux/amd64 and linux/arm64/v8 machines along with its dependencies _(without systemd support)_:
 * [podman](https://github.com/containers/podman)
-* [runc](https://github.com/opencontainers/runc/) or [crun](https://github.com/containers/crun)
+* [crun](https://github.com/containers/crun)
+* [runc](https://github.com/opencontainers/runc/)
 * [conmon](https://github.com/containers/conmon)
 * [fuse-overlayfs](https://github.com/containers/fuse-overlayfs) and [libfuse](https://github.com/libfuse/libfuse)
-* [slirp4netns](https://github.com/rootless-containers/slirp4netns) (with [libslirp](https://gitlab.freedesktop.org/slirp/libslirp))
-* [CNI plugins](https://github.com/containernetworking/plugins): loopback, bridge, host-local, portmap, firewall, tuning
+* [Netavark](https://github.com/containers/netavark): container network stack and default in podman 5 or later
+  * [passt/pasta](https://passt.top/passt/)
+  * [aardvark-dns](https://github.com/containers/aardvark-dns)
 * [catatonit](https://github.com/openSUSE/catatonit)
+
+CNI networking has been replaced with Netavark since Podman version 5.
 
 ## Container image
 
@@ -15,8 +19,8 @@ The following image tags are supported:
 
 | Tag | Description |
 | --- | ----------- |
-| `latest`, `<VERSION>` | podman with both rootless and rootful dependencies: runc, conmon, fuse-overlayfs, slirp4netns, CNI plugins, catatonit. |
-| `minimal`, `<VERSION>-minimal` | podman, crun, fuse-overlayfs and conmon binaries, configured to use the host's existing namespaces (low isolation level). |
+| `latest`, `<VERSION>` | podman with all dependencies: runc, crun, conmon, fuse-overlayfs, netavark, pasta, aardvark-dns, catatonit. |
+| `minimal`, `<VERSION>-minimal` | podman, crun, conmon, fuse-overlayfs and netavark binaries, configured to use the host's existing namespaces (low isolation level). |
 | `remote`, `<VERSION>-remote` | the podman remote binary. |
 
 By default containers are run as user `root`.
@@ -73,6 +77,8 @@ The following binaries should be installed on your host:
 * `nsenter`
 * `uidmap` (for rootless mode)
 
+[nftables](https://netfilter.org/projects/nftables/) (with or without optional iptables-nft wrapper) to be included in the future [WIP](https://github.com/containers/netavark/pull/883).  
+
 In order to run rootless containers that use multiple uids/gids you may want to set up a uid/gid mapping for your user on your host:
 ```
 sudo sh -c "echo $(id -un):100000:200000 >> /etc/subuid"
@@ -80,7 +86,7 @@ sudo sh -c "echo $(id -gn):100000:200000 >> /etc/subgid"
 ```
 _Please make sure you don't add the mapping multiple times._  
 
-To support applications that use the `docker` command you may want to link it to `podman` as follows:
+To support applications that rely on the `docker` command, a quick option is to link `podman` as follows:
 ```sh
 sudo ln -s /usr/local/bin/podman /usr/local/bin/docker
 ```

--- a/conf/containers/containers.conf
+++ b/conf/containers/containers.conf
@@ -1,7 +1,4 @@
 # See https://github.com/containers/common/blob/master/pkg/config/containers.conf
-[containers]
-init_path = "/usr/local/lib/podman/catatonit"
-
 [engine]
 cgroup_manager = "cgroupfs"
 events_logger="file"

--- a/conf/crun-containers.conf
+++ b/conf/crun-containers.conf
@@ -7,6 +7,7 @@ ipcns="host"
 utsns="host"
 cgroupns="host"
 cgroups="disabled"
+log_driver = "k8s-file"
 [engine]
 cgroup_manager = "cgroupfs"
 events_logger="file"

--- a/test/remote.bats
+++ b/test/remote.bats
@@ -27,7 +27,7 @@ teardown_file() {
 		podman --url=tcp://$PODMAN_ADDRESS run alpine:3.17 echo hello from remote container
 }
 
-@test "remote podman - build image from dockerfile" {
+@test "remote podman - build dockerfile" {
 	# ATTENTION: podman remote fails if it cannot map the uids/gids from the server locally as well (which is why podman-remote user has been added)
 	$DOCKER run --rm --network=host --user=podman-remote:podman-remote --pull=never \
 		"${PODMAN_REMOTE_IMAGE}" \

--- a/test/rootful.bats
+++ b/test/rootful.bats
@@ -13,7 +13,7 @@ skipIfDockerUnavailableAndNotRunAsRoot() {
 	fi
 }
 
-@test "rootful podman - internet connectivity (CNI networking)" {
+@test "rootful podman - internet connectivity (using netavark + pasta)" {
 	skipIfDockerUnavailableAndNotRunAsRoot
 	$DOCKER run --rm --privileged --entrypoint /bin/sh -u root:root \
 		-v "$PODMAN_ROOT_DATA_DIR:/var/lib/containers/storage" \
@@ -21,7 +21,7 @@ skipIfDockerUnavailableAndNotRunAsRoot() {
 		-c 'podman run --rm alpine:3.17 wget -O /dev/null http://example.org'
 }
 
-@test "rootful podman - build image from dockerfile" {
+@test "rootful podman - build dockerfile" {
 	skipIfDockerUnavailableAndNotRunAsRoot
 	$DOCKER run --rm --privileged --entrypoint /bin/sh -u root:root \
 		-v "$PODMAN_ROOT_DATA_DIR:/var/lib/containers/storage" \
@@ -34,7 +34,7 @@ skipIfDockerUnavailableAndNotRunAsRoot() {
 			EOF'
 }
 
-@test "rootful podman - port mapping" {
+@test "rootful podman - port forwarding" {
 	skipIfDockerUnavailableAndNotRunAsRoot
-	testPortMapping -u root:root -v "$PODMAN_ROOT_DATA_DIR:/var/lib/containers/storage" "${PODMAN_IMAGE}"
+	testPortForwarding -u root:root -v "$PODMAN_ROOT_DATA_DIR:/var/lib/containers/storage" "${PODMAN_IMAGE}"
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # ARGS: DOCKER_RUN_OPTS
-testPortMapping() {
+testPortForwarding() {
 	$DOCKER run --rm -i --privileged --entrypoint /bin/sh --pull=never $@ - <<-EOF
 		set -ex
 		podman pull nginxinc/nginx-unprivileged:1.20-alpine
 		podman run -p 8182:8080 --entrypoint=/bin/sh nginxinc/nginx-unprivileged:1.20-alpine -c 'timeout 15 nginx -g "daemon off;"' &
 		sleep 5
-		wget -O - localhost:8182
+		wget -O - 127.0.0.1:8182
 	EOF
 }


### PR DESCRIPTION
Upgrade to Podman 5.1.1 and drop CNI networking and slirp4netns in favour of netavark (statically linked) and pasta.

This is a follow-up of #87 and #90.