### PR TITLE
Document apparmor profile update, fix GHA workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push'
 
     steps:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Check out code

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ For more information see [podman's rootless installation instructions](https://g
 
 ### Host configuration
 
+#### Additional binaries
+
 The following binaries should be installed on your host:
 * `iptables`
 * `nsenter`
@@ -79,12 +81,24 @@ The following binaries should be installed on your host:
 
 [nftables](https://netfilter.org/projects/nftables/) (with or without optional iptables-nft wrapper) to be included in the future [WIP](https://github.com/containers/netavark/pull/883).  
 
+#### UID/GID mapping
+
 In order to run rootless containers that use multiple uids/gids you may want to set up a uid/gid mapping for your user on your host:
-```
+```sh
 sudo sh -c "echo $(id -un):100000:200000 >> /etc/subuid"
 sudo sh -c "echo $(id -gn):100000:200000 >> /etc/subgid"
 ```
 _Please make sure you don't add the mapping multiple times._  
+
+#### apparmor profile
+
+On an apparmor-enabled host such as Ubuntu >=23.04, podman may fail with `reexec: Permission denied` the first time it is run.
+In that case you have to change your podman apparmor profile at `/etc/apparmor.d/podman` so that it also applies to `/usr/local/bin/podman` as follows (also see [here](https://github.com/containers/podman/issues/24642#issuecomment-2582629496)):
+```sh
+sudo sed -Ei 's!^profile podman /usr/bin/podman !profile podman /usr/{bin,local/bin}/podman !' /etc/apparmor.d/podman
+```
+
+#### docker link
 
 To support applications that rely on the `docker` command, a quick option is to link `podman` as follows:
 ```sh


### PR DESCRIPTION
* Closes #111: Document required apparmor profile change on Ubuntu >=23.04.
* To fix the e2e tests within the GHA workflow, let it run on an Ubuntu 22.04 VM instead of running on Ubuntu 24.04.

Relates to https://github.com/containers/podman/issues/24642 and #115