### PR TITLE
fix: don't publish quadlet with image but with tar archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -195,7 +195,11 @@ COPY conf/crun-containers.conf /etc/containers/containers.conf
 FROM rootlesspodmanbase AS podmanall
 RUN apk add --no-cache iptables ip6tables
 COPY --from=catatonit /catatonit/catatonit /usr/local/lib/podman/catatonit
-COPY --from=podman /usr/local/libexec/podman/quadlet /usr/local/libexec/podman/quadlet
 COPY --from=runc   /usr/local/bin/runc   /usr/local/bin/runc
 COPY --from=aardvark-dns /aardvark-dns/target/release/aardvark-dns /usr/local/lib/podman/aardvark-dns
 COPY --from=podman /etc/containers/seccomp.json /etc/containers/seccomp.json
+
+FROM podmanall AS tar-archive
+COPY --from=podman /usr/local/libexec/podman/quadlet /usr/local/libexec/podman/quadlet
+
+FROM podmanall

--- a/test/rootful.bats
+++ b/test/rootful.bats
@@ -38,25 +38,3 @@ skipIfDockerUnavailableAndNotRunAsRoot() {
 	skipIfDockerUnavailableAndNotRunAsRoot
 	testPortForwarding -u root:root -v "$PODMAN_ROOT_DATA_DIR:/var/lib/containers/storage" "${PODMAN_IMAGE}"
 }
-
-@test "$TEST_PREFIX quadlet - generate service" {
-	if [ "${TEST_SKIP_QUADLET:-}" = true ]; then
-		skip "TEST_SKIP_QUADLET=true"
-	fi
-	$DOCKER run --rm -u podman:podman \
-		-v "$BATS_TEST_DIRNAME/quadlet/hello_world.container:/etc/containers/systemd/hello_world.container" \
-		--pull=never "${PODMAN_IMAGE}" \
-		/usr/local/libexec/podman/quadlet -dryrun > /tmp/test.service # this goes to tmp because we are not root below
-
-	expected_values=(
-        "--name hello_world"
-        "--publish 8080:8080"
-        "--env HELLO=WORLD"
-        "docker.io/hello-world"
-    )
-
-    for value in "${expected_values[@]}"; do
-        run grep -q -- "$value" "/tmp/test.service"
-        [ "$status" -eq 0 ] || fail "Expected '$value' not found in /tmp/test.service"
-    done
-}

--- a/test/tar.bats
+++ b/test/tar.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+: ${DOCKER:=docker}
+: ${PODMAN_TAR_IMAGE:=mgoltzsche/podman:latest-tar}
+
+@test "tar - quadlet - generate service" {
+	if [ "${TEST_SKIP_QUADLET:-}" = true ]; then
+		skip "TEST_SKIP_QUADLET=true"
+	fi
+	$DOCKER run --rm -u podman:podman \
+		-v "$BATS_TEST_DIRNAME/quadlet/hello_world.container:/etc/containers/systemd/hello_world.container" \
+		--pull=never "${PODMAN_TAR_IMAGE}" \
+		/usr/local/libexec/podman/quadlet -dryrun > /tmp/test.service # this goes to tmp because we are not root below
+
+	expected_values=(
+        "--name hello_world"
+        "--publish 8080:8080"
+        "--env HELLO=WORLD"
+        "docker.io/hello-world"
+    )
+
+    for value in "${expected_values[@]}"; do
+        run grep -q -- "$value" "/tmp/test.service"
+        [ "$status" -eq 0 ] || fail "Expected '$value' not found in /tmp/test.service"
+    done
+}


### PR DESCRIPTION
Add a separate stage to the Dockerfile to build the root file system of the tar archive and make the tar targets within the Makefile build that stage.

This is a follow-up of #119
Relates to #120
cc @cryi