### PR TITLE
Implement rootfulall target on upstream v5.4.2

### DIFF
--- a/conf/containers/storage.conf
+++ b/conf/containers/storage.conf
@@ -73,10 +73,14 @@ ignore_chown_errors = "true"
 
 # Path to an helper program to use for mounting the file system instead of mounting it
 # directly.
-mount_program = "/usr/local/bin/fuse-overlayfs"
+# 2024-06-02 kb2ma Don't specify program, so will use kernel's native overlay driver.
+#            We don't need to support rootless.
+#mount_program = "/usr/local/bin/fuse-overlayfs"
 
 # mountopt specifies comma separated list of extra mount options
-mountopt = "nodev,fsync=0"
+# 2024-06-02 kb2ma Disable to fix for error when mounting storage. Likely related
+#            to use of native overlays rather than fuse-overlayfs.
+#mountopt = "nodev,fsync=0"
 
 # Set to skip a PRIVATE bind mount on the storage home directory.
 # skip_mount_home = "false"


### PR DESCRIPTION
The rootfulall target builds without rootless components.