### PR TITLE
Update Dockerfile - add bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,7 +159,7 @@ RUN set -ex; \
 # Build podman base image
 FROM alpine:3.20 AS podmanbase
 LABEL maintainer="Max Goltzsche <max.goltzsche@gmail.com>"
-RUN apk add --no-cache tzdata ca-certificates
+RUN apk add --no-cache tzdata ca-certificates bash
 COPY --from=conmon /conmon/bin/conmon /usr/local/lib/podman/conmon
 COPY --from=podman /usr/local/lib/podman/rootlessport /usr/local/lib/podman/rootlessport
 COPY --from=podman /usr/local/bin/podman /usr/local/bin/podman


### PR DESCRIPTION
Fix OCI runtime exec error in Dagger GitHub Action by updating shell command OCI runtime exec failed: exec failed: unable to start container process: exec: "bash": executable file not found in $PATH occurs when the container image lacks bash.