### PR TITLE
fix: bump podman 5.5.2 + dependency updates

### DIFF
--- a/Dockerfile-remote
+++ b/Dockerfile-remote
@@ -1,5 +1,5 @@
 # podman build base
-FROM golang:1.23-alpine3.20 AS podmanbuildbase
+FROM golang:1.24-alpine3.22 AS podmanbuildbase
 RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 	btrfs-progs btrfs-progs-dev libassuan-dev lvm2-dev device-mapper \
 	glib-static libc-dev gpgme-dev protobuf-dev protobuf-c-dev \
@@ -9,7 +9,7 @@ RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 # podman remote
 FROM podmanbuildbase AS podman-remote
 RUN apk add --update --no-cache curl
-ARG PODMAN_VERSION=v5.5.1
+ARG PODMAN_VERSION=v5.5.2
 RUN git clone -c advice.detachedHead=false --depth=1 --branch=${PODMAN_VERSION} https://github.com/containers/podman src/github.com/containers/podman
 WORKDIR $GOPATH/src/github.com/containers/podman
 RUN set -eux; \
@@ -20,6 +20,6 @@ RUN set -eux; \
 	podman --help >/dev/null; \
 	[ "$(ldd /usr/local/bin/podman-remote | wc -l)" -eq 0 ] || (ldd /usr/local/bin/podman-remote; false)
 
-FROM alpine:3.20
+FROM alpine:3.22
 COPY --from=podman-remote /usr/local/bin /usr/local/bin
 RUN adduser -D podman-remote -h /podman -u 1000

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ run:
 		$(PODMAN_IMAGE) /bin/sh
 
 clean:
-	$(DOCKER) run --rm -v "`pwd`:/work" alpine:3.20 rm -rf /work/build
+	$(DOCKER) run --rm -v "`pwd`:/work" alpine:3.22 rm -rf /work/build
 
 run-server: podman-ssh
 	# TODO: make sshd log to stdout (while still ensuring that we know when it is available)

--- a/test/pod.yaml
+++ b/test/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: build
-    image: alpine:3.17
+    image: alpine:3.22
     command: ["/bin/sh"]
     args:
     - -c

--- a/test/remote.bats
+++ b/test/remote.bats
@@ -24,7 +24,7 @@ teardown_file() {
 
 @test "remote podman - run container" {
 	$DOCKER run --rm --network=host --pull=never "${PODMAN_REMOTE_IMAGE}" \
-		podman --url=tcp://$PODMAN_ADDRESS run alpine:3.17 echo hello from remote container
+		podman --url=tcp://$PODMAN_ADDRESS run alpine:3.22 echo hello from remote container
 }
 
 @test "remote podman - build dockerfile" {
@@ -33,7 +33,7 @@ teardown_file() {
 		"${PODMAN_REMOTE_IMAGE}" \
 		sh -c "set -ex; \
 			mkdir /tmp/testcontext
-			printf 'FROM alpine:3.17\nRUN echo hello\nCMD [ "/bin/echo", "hello" ]' > /tmp/testcontext/Dockerfile
+			printf 'FROM alpine:3.22\nRUN echo hello\nCMD [ "/bin/echo", "hello" ]' > /tmp/testcontext/Dockerfile
 			podman --log-level=debug --remote --url=tcp://$PODMAN_ADDRESS build -t testbuild -f /tmp/testcontext/Dockerfile /tmp/testcontext; \
 			podman --url=tcp://$PODMAN_ADDRESS run testbuild echo hello from remote container"
 }

--- a/test/rootful.bats
+++ b/test/rootful.bats
@@ -18,7 +18,7 @@ skipIfDockerUnavailableAndNotRunAsRoot() {
 	$DOCKER run --rm --privileged --entrypoint /bin/sh -u root:root \
 		-v "$PODMAN_ROOT_DATA_DIR:/var/lib/containers/storage" \
 		--pull=never "${PODMAN_IMAGE}" \
-		-c 'podman run --rm alpine:3.17 wget -O /dev/null http://example.org'
+		-c 'podman run --rm alpine:3.22 wget -O /dev/null http://example.org'
 }
 
 @test "rootful podman - build dockerfile" {

--- a/test/rootless.bats
+++ b/test/rootless.bats
@@ -20,20 +20,20 @@ teardown_file() {
 	$DOCKER run --rm --privileged -u podman:podman \
 		-v "$PODMAN_ROOT_DATA_DIR:/podman/.local/share/containers/storage" \
 		--pull=never "${PODMAN_IMAGE}" \
-		docker run --rm alpine:3.17 wget -O /dev/null http://example.org
+		docker run --rm alpine:3.22 wget -O /dev/null http://example.org
 }
 
 @test "$TEST_PREFIX podman - uid mapping (using fuse-overlayfs) {
 	$DOCKER run --rm --privileged -u podman:podman \
 		-v "$PODMAN_ROOT_DATA_DIR:/podman/.local/share/containers/storage" \
 		--pull=never "${PODMAN_IMAGE}" \
-		docker run --rm alpine:3.17 /bin/sh -c 'set -ex; touch /file; chown guest /file; [ $(stat -c %U /file) = guest ]'
+		docker run --rm alpine:3.22 /bin/sh -c 'set -ex; touch /file; chown guest /file; [ $(stat -c %U /file) = guest ]'
 }
 
 @test "$TEST_PREFIX podman - unmapped uid" {
 	$DOCKER run --rm --privileged --user 9000:9000 -e HOME=/tmp \
 		--pull=never "${PODMAN_IMAGE}" \
-		docker run --rm alpine:3.17 wget -O /dev/null http://example.org
+		docker run --rm alpine:3.22 wget -O /dev/null http://example.org
 }
 
 @test "$TEST_PREFIX podman - build image from dockerfile" {
@@ -42,7 +42,7 @@ teardown_file() {
 		--pull=never "${PODMAN_IMAGE}" \
 		-c 'set -e;
 			podman build -t podmantestimage -f - . <<-EOF
-				FROM alpine:3.17
+				FROM alpine:3.22
 				RUN echo hello world > /hello
 				CMD ["/bin/cat", "/hello"]
 			EOF'


### PR DESCRIPTION
* podman 5.5.2
* passt 2025_06_11.0293c6f
* alpine 3.22 base image
* Go-based binaries built using Go 1.24
* Rust-based binaries built using Rust 1.87