### PR TITLE
feat: bump podman 5.6.1 + dependencies

### DIFF
--- a/Dockerfile-remote
+++ b/Dockerfile-remote
@@ -1,5 +1,5 @@
 # podman build base
-FROM golang:1.24-alpine3.22 AS podmanbuildbase
+FROM golang:1.25.1-alpine3.22 AS podmanbuildbase
 RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 	btrfs-progs btrfs-progs-dev libassuan-dev lvm2-dev device-mapper \
 	glib-static libc-dev gpgme-dev protobuf-dev protobuf-c-dev \
@@ -9,7 +9,7 @@ RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 # podman remote
 FROM podmanbuildbase AS podman-remote
 RUN apk add --update --no-cache curl
-ARG PODMAN_VERSION=v5.6.0
+ARG PODMAN_VERSION=v5.6.1
 RUN git clone -c advice.detachedHead=false --depth=1 --branch=${PODMAN_VERSION} https://github.com/containers/podman src/github.com/containers/podman
 WORKDIR $GOPATH/src/github.com/containers/podman
 RUN set -eux; \


### PR DESCRIPTION
This upgrades multiple components to their latest versions:
- build-stack: alpine from 3.22 to 3.22.1
- build-stack: golang from 1.24 to 1.25.1
- build-stack: rust from 1.87 to 1.89
- podman from v5.6.0 to v5.6.1
- fuse-overlayfs from v1.14 to v1.15
- runc from v1.3.0 to v1.3.1
- netavark from v1.15.0 to v1.16.1
- aardvark-dns from v1.15.0 to v1.16.0

Hint: fuse v3.17.x currently can't be built statically in Alpine.

Resolves https://github.com/mgoltzsche/podman-static/issues/142