### PR TITLE
feat: bump podman 5.6.2 + dependencies

### DIFF
--- a/Dockerfile-remote
+++ b/Dockerfile-remote
@@ -1,5 +1,5 @@
 # podman build base
-FROM golang:1.25.1-alpine3.22 AS podmanbuildbase
+FROM golang:1.25-alpine3.22 AS podmanbuildbase
 RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 	btrfs-progs btrfs-progs-dev libassuan-dev lvm2-dev device-mapper \
 	glib-static libc-dev gpgme-dev protobuf-dev protobuf-c-dev \
@@ -9,7 +9,7 @@ RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 # podman remote
 FROM podmanbuildbase AS podman-remote
 RUN apk add --update --no-cache curl
-ARG PODMAN_VERSION=v5.6.1
+ARG PODMAN_VERSION=v5.6.2
 RUN git clone -c advice.detachedHead=false --depth=1 --branch=${PODMAN_VERSION} https://github.com/containers/podman src/github.com/containers/podman
 WORKDIR $GOPATH/src/github.com/containers/podman
 RUN set -eux; \


### PR DESCRIPTION
Updates several software components to newer versions:
- podman from 5.6.1 to 5.6.2
- crun from 1.23.1 to 1.24
- rust from 1.89 to 1.90
- passt from 2025_08_05.309eefd to 2025_09_19.623dbf6

Removed version pinning for Alpine & Golang for better maintenance.

Hint: fuse v3.17.x currently can't be built statically in Alpine.