### PR TITLE
feat: update podman to v5.7.0 and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,20 +13,15 @@ RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 
 
 # runc
-# BUILDMODE: pie = position-independent executable, exe = standard executable
 FROM golangbuildbase AS runc
 ARG RUNC_VERSION=v1.3.3
-ARG BUILDMODE=pie
 RUN git clone -c 'advice.detachedHead=false' --depth=1 --branch ${RUNC_VERSION} https://github.com/opencontainers/runc src/github.com/opencontainers/runc
 WORKDIR $GOPATH/src/github.com/opencontainers/runc
 RUN set -eux; \
-	go build -ldflags "-s -w -linkmode external -extldflags '-static'" -buildmode="${BUILDMODE}"; \
+	make static EXTRA_LDFLAGS="-s -w"; \
 	make install; \
 	runc --version; \
-	case "$BUILDMODE" in \
-		exe)   ldd /usr/local/sbin/runc ;; \
-		pie) ! ldd /usr/local/sbin/runc ;; \
-	esac
+	ldd /usr/local/sbin/runc
 
 
 # podman (without systemd support)

--- a/Dockerfile-remote
+++ b/Dockerfile-remote
@@ -9,7 +9,7 @@ RUN apk add --update --no-cache git make gcc pkgconf musl-dev \
 # podman remote
 FROM podmanbuildbase AS podman-remote
 RUN apk add --update --no-cache curl
-ARG PODMAN_VERSION=v5.6.2
+ARG PODMAN_VERSION=v5.7.0
 RUN git clone -c advice.detachedHead=false --depth=1 --branch=${PODMAN_VERSION} https://github.com/containers/podman src/github.com/containers/podman
 WORKDIR $GOPATH/src/github.com/containers/podman
 RUN set -eux; \


### PR DESCRIPTION
Update container tooling components to latest versions:

- podman from v5.6.2 to v5.7.0
- runc from v1.3.1 to v1.3.3
- rust from v1.90 to v1.91
- netavark from v1.16.1 to v1.17.0
- aardvark-dns from v1.16.0 to v1.17.0
- fuse v3.16.2 to v3.17.4
- fuse-overlayfs from v1.15 to v1.16
- crun from v1.24 to v1.25

Remove specific version pinning for Alpine base image for better maintenance.

Also, builds the `runc` and `crun` binaries from source as opposed to downloading them.

Closes #150
