### PR TITLE
Install shell completions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,11 @@ RUN set -ex; \
 	mkdir -p /usr/local/lib/podman; \
 	mv bin/rootlessport /usr/local/lib/podman/rootlessport; \
 	! ldd /usr/local/lib/podman/rootlessport
+# copying completions to /comp instead of /usr/local/share to avoid copying potentially other unwanted stuff in the final stage
+RUN set -eux; \
+	install -Dm644 -t /comp/bash-completion/completions/ completions/bash/podman; \
+	install -Dm644 -t /comp/zsh/site-functions/ completions/zsh/_podman; \
+	install -Dm644 -t /comp/fish/vendor_completions.d/ completions/fish/podman.fish
 
 
 # conmon (without systemd support)
@@ -164,6 +169,7 @@ RUN apk add --no-cache tzdata ca-certificates
 COPY --from=conmon /conmon/bin/conmon /usr/local/lib/podman/conmon
 COPY --from=podman /usr/local/lib/podman/rootlessport /usr/local/lib/podman/rootlessport
 COPY --from=podman /usr/local/bin/podman /usr/local/bin/podman
+COPY --from=podman /comp /usr/local/share
 COPY --from=passt /passt/bin/ /usr/local/bin/
 COPY --from=netavark /netavark/target/release/netavark /usr/local/lib/podman/netavark
 COPY conf/containers /etc/containers

--- a/Dockerfile-remote
+++ b/Dockerfile-remote
@@ -19,7 +19,13 @@ RUN set -eux; \
 	ln -s podman-remote /usr/local/bin/docker; \
 	podman --help >/dev/null; \
 	[ "$(ldd /usr/local/bin/podman-remote | wc -l)" -eq 0 ] || (ldd /usr/local/bin/podman-remote; false)
+# copying completions to /comp instead of /usr/local/share to avoid copying potentially other unwanted stuff in the final stage
+RUN set -eux; \
+	install -Dm644 -t /comp/bash-completion/completions/ completions/bash/podman-remote; \
+	install -Dm644 -t /comp/zsh/site-functions/ completions/zsh/_podman-remote; \
+	install -Dm644 -t /comp/fish/vendor_completions.d/ completions/fish/podman-remote.fish
 
 FROM alpine:3.22
 COPY --from=podman-remote /usr/local/bin /usr/local/bin
+COPY --from=podman-remote /comp /usr/local/share
 RUN adduser -D podman-remote -h /podman -u 1000

--- a/Makefile
+++ b/Makefile
@@ -117,9 +117,10 @@ tar: .podman-from-container
 .podman-from-container: IMAGE_ROOTFS = $(BUILD_DIR)/images/podman/linux_$(ARCH)
 .podman-from-container: podman-tar-image
 	rm -rf $(ASSET_DIR)
-	mkdir -p $(ASSET_DIR)/etc $(ASSET_DIR)/usr/local/lib/systemd/{system,user}-generators
+	mkdir -p $(ASSET_DIR)/etc $(ASSET_DIR)/usr/local/lib/systemd/{system,user}-generators $(ASSET_DIR)/usr/local/share
 	cp -rt $(ASSET_DIR)/etc $(IMAGE_ROOTFS)/etc/containers
 	cp -rt $(ASSET_DIR)/usr/local $(IMAGE_ROOTFS)/usr/local/{bin,lib,libexec}
+	cp -rt $(ASSET_DIR)/usr/local/share $(IMAGE_ROOTFS)/usr/local/share/{bash-completion,zsh,fish}
 	ln -s ../../../libexec/podman/quadlet $(ASSET_DIR)/usr/local/lib/systemd/user-generators/podman-user-generator
 	ln -s ../../../libexec/podman/quadlet $(ASSET_DIR)/usr/local/lib/systemd/system-generators/podman-system-generator
 	cp README.md $(ASSET_DIR)/

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Before uninstalling the binaries, you may remove containers, pods, images, volum
 sudo podman system reset
 ```
 
-Next, remove all the copied binaries from the following folders:
+Next, remove all the copied binaries and support files from the following folders:
 
 ```sh
 sudo rm -rf /etc/containers/*
@@ -148,4 +148,5 @@ sudo rm -rf /usr/local/bin/{crun,fuse-overlayfs,fusermount3,pasta,pasta.avx2,pod
 sudo rm -rf /usr/local/{lib,libexec}/podman
 sudo rm -rf /usr/local/lib/systemd/{system,user}/podman*
 sudo rm /usr/local/lib/systemd/{system,user}-generators/podman-*-generator
+sudo rm /usr/local/share/{bash-completion/completions/podman,zsh/site-functions/_podman,fish/vendor_completions.d/podman.fish}
 ```


### PR DESCRIPTION
Closes #153.

One thing remaining:

In the example in README, it appears that the intended way to use the container images is to directly specify `podman ...` as the container command. In that case obviously these completion files wouldn't be any use. They are only useful if the user **1. installs a supported shell [bash|zsh|fish] (and `bash-completion` in case of bash)** AND **2. shell into the container using one of said shells**.

This leaves me torn on whether or not I should install those shells by default in the images. On one hand, without any supported shell included, those completion files are useless. Users will have to install the shell by themselves, which is greatly inconvenient. On the other hand, including the shells in the image would raise the image size, likely unnecessarily due to the aforementioned intended usage. Currently it's about 14MB for just bash; 46MB for bash, zsh, and fish.

TBH my opinion on this is not strong. I only use the tarball distribution so none of this really impacts me. I'd like to know what you think.