### PR TITLE
docs: update host additional binaries (fix #163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,9 @@ For more information see [podman's rootless installation instructions](https://g
 #### Additional binaries
 
 The following binaries should be installed on your host:
-* `iptables`
+* `nftables` (with `iptables-nft` wrapper if `iptables` compatibility is needed)
 * `nsenter`
-* `uidmap` (for rootless mode)
-
-[nftables](https://netfilter.org/projects/nftables/) (with or without optional iptables-nft wrapper) to be included in the future [WIP](https://github.com/containers/netavark/pull/883).  
+* `shadow` / `shadow-utils` providing `newuidmap` and `newgidmap` (for rootless mode, package `uidmap` on Debian/Ubuntu)  
 
 #### UID/GID mapping
 


### PR DESCRIPTION
Fixes #163

- `uidmap` binary does not exist on Fedora/RHEL8/Arch - correct is `shadow`/`shadow-utils` providing `newuidmap`/`newgidmap` (Debian/Ubuntu package `uidmap` provides these)
- `nftables` is required since Podman 6.0 ([containers/netavark#883](https://github.com/containers/netavark/pull/883) merged), `iptables` support was removed - README was still on WIP state

